### PR TITLE
Update "Building FEniCS from source" link

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -71,4 +71,4 @@ input/output facilities.
 
 ## Building FEniCS from source
 For installation in high performance computing clusters we recommend always building from source.
-For detailed instructions, see the [FEniCS Reference Manual](http://fenics-containers.readthedocs.io/en/latest/index.html).
+For detailed instructions, see the [FEniCS Reference Manual](https://fenics.readthedocs.io/en/latest/installation.html).


### PR DESCRIPTION
Hi,

The current link for "Building FEniCS from source" on the downloads page (https://fenicsproject.org/download/) points to the page on containers (https://fenics.readthedocs.io/projects/containers/en/latest/index.html). Would it be better to point to the installation page (https://fenics.readthedocs.io/en/latest/installation.html) that also covers building from source? If so, I updated the link in this pull request.
