### PR TITLE
Link to conferences from community page

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -54,6 +54,15 @@ join the **#fenicsx** and **#development** channels.
 [Here](people-of-fenics.md) we introduce some the users of FEniCS who
 have found it useful.
 
+
+## The FEniCS Conference
+
+The [FEniCS Conference](../conference/index.md) is held annually and
+is a great way to network with other users, keep up with new
+developments from core developers, hear new applications and results,
+and discuss ways of improving your projects.
+
+
 ## Code of Conduct
 
 We strive to make the FEniCS Project an open and respectful community.

--- a/community/people-of-fenics.md
+++ b/community/people-of-fenics.md
@@ -13,7 +13,7 @@ take part, for example: in the [Discourse
 group](https://fenicsproject.discourse.group/), on our [Slack
 channel](https://fenicsproject.slack.com/), contributing to the [source
 code](https://github.com/FEniCS) or joining us at one of the
-[conferences](../conference/2021.md).
+[conferences](../conference/index.md).
 
 The distinctiveness of all our backgrounds, combined with our individual
 ambitions, drives innovation in the FEniCS Project. Drawing from this


### PR DESCRIPTION
A link to the past conferences was missing on the website, apart from a link on the People of FEniCS page.  The community page is a good place for it.  Also updates the People of FEniCS link to the page of all conferences.