### PR TITLE
Update README with Ruby 3.0+ instructions for local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,11 @@ The website can be served locally (so it can then be opened in a browser) by run
 ```bash
 bundle exec jekyll serve
 ```
+
+when using Ruby 2.7, or
+
+```bash
+bash -c 'cd _site && python3 -m http.server 3000'
+```
+
+when using Ruby 3.0+.


### PR DESCRIPTION
When building locally I always end up encountering the error reported in https://stackoverflow.com/questions/66113639/jekyll-serve-throws-no-implicit-conversion-of-hash-into-integer-error

This temporary fix is very easy to find, but it might still be worthwhile to add this to the README file.