### PR TITLE
Use default `github.token` on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - run: sudo apt-get install -y ruby-bundler
         name: Install prerequisites
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: bundle install
         name: Install bundle
       - run: bundle exec jekyll build

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     container: dolfinx/dolfinx:stable
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: pip3 install pytest flake8
         name: Install pytest and flake8
       - run: pip3 install -r _test/requirements.txt

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,5 +25,15 @@ jobs:
         name: Run flake8 on tests
       - run: flake8 _tools/
         name: Run flake8 on tools
-      - run: GITHUB_TOKEN=${{ secrets.symfembot_token }} python3 -m pytest _test/ --has-fenicsx 1
+      - run: |
+          TOKEN=${{ secrets.symfembot_token }}
+          if [ -n "${TOKEN}" ]; then
+            echo "token=${TOKEN}" >> ${GITHUB_OUTPUT}
+          else
+            echo "token=${{ github.token }}" >> ${GITHUB_OUTPUT}
+          fi
+        shell: bash
+        name: Determine which token to use when running tests
+        id: token
+      - run: GITHUB_TOKEN=${{ steps.token.outputs.token }} python3 -m pytest _test/ --has-fenicsx 1
         name: Run tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,7 @@ on:
       - main
   schedule:
     - cron: "0 7 * * 1"
+  workflow_dispatch:
 
 jobs:
   run-tests:


### PR DESCRIPTION
* test on this branch, this repository (success): https://github.com/FEniCS/web/actions/runs/7014785090
* test on current main branch, forked repository (failure, as shown in #152): https://github.com/francesco-ballarin/fenics-web/actions/runs/7014801099
* test on this branch, forked repository (success): https://github.com/francesco-ballarin/fenics-web/actions/runs/7014800374