### PR TITLE
easiest installation on Debian/Ubuntu is apt

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -56,3 +56,31 @@ FEniCS ({{ site.fenicsversion }}) was released in
 {{ site.fenicsversiondate }}.
 Instructions for installing the legacy FEniCS (version {{
 site.fenicsversion }}) can be found [here](archive.md).
+
+## Complex number support
+
+FEniCSx introduces complex number support.
+
+On Debian/Ubuntu Linux this is provided via the python3-dolfinx-complex package:
+
+```shell
+sudo apt install python3-dolfinx-complex
+```
+
+Debian/Ubuntu packages manage dolfinx builds via the version of PETSc they are built against.
+The Debian/Ubuntu standard installation uses the real number build. To access other
+builds, set the environment variable PETSC_DIR to point at the required PETSc version
+located under /usr/lib/petscdir. Likewise SLEPc support can be managed via SLEPC_DIR
+(see /usr/lib/slepcdir).
+
+So to access complex number support in dolfinx on Debian/Ubuntu, run scripts with:
+
+```shell
+PETSC_DIR=/usr/lib/petscdir/petsc-complex python3 demo_dolfinx.py
+```
+
+or, with SLEPc:
+
+```shell
+PETSC_DIR=/usr/lib/petscdir/petsc-complex SLEPC_DIR=/usr/lib/slepcdir/slepc-complex python3 demo_dolfinx.py
+```

--- a/download/index.md
+++ b/download/index.md
@@ -8,12 +8,21 @@ permalink: /download/
 
 The latest stable release of FEniCSx is version {{ site.fenicsxversion }},
 which was released in {{ site.fenicsxversiondate }}. The easiest way to start using FEniCSx
-is to install it using [conda](https://conda.io):
+on MacOS and other systems is to install it using [conda](https://conda.io):
 
 ```shell
 conda create -n fenicsx-env
 conda activate fenicsx-env
 conda install -c conda-forge fenics-dolfinx mpich pyvista
+```
+
+The easiest way to install FEniCSx on Debian or Ubuntu Linux
+is via apt:
+
+```shell
+sudo add-apt-repository ppa:fenics-packages/fenics
+sudo apt update
+sudo apt install fenicsx
 ```
 
 ## Other installation options


### PR DESCRIPTION
conda introduces additional complications which make it not the easy way to install FEniCS on a Debian or Ubuntu (apt) based system.