### PR TITLE
Fix formatting and update registration fees in 2026.md

### DIFF
--- a/conference/2026.md
+++ b/conference/2026.md
@@ -22,7 +22,7 @@ community. It will be hosted in **Paris (France)** at
 [University of Chicago | John W. Boyer Center](https://centerinparis.uchicago.edu/).
 
 We welcome developers, existing and potential users of the
-FEniCS ecosystem as well as mathematicians, computer scientists and
+FEniCS ecosystem as well as mathematicians, computer scientists, and
 application domain specialists interested in numerical methods, their
 implementation and applications.
 
@@ -43,7 +43,7 @@ Links to previous FEniCS conferences can be found [here](index.md).
 
 ## Features
 
-- Single track session for talks.
+- Single-track session for talks.
 - Dedicated poster session including presentation of FEniCS-based software packages.
 - Plenty of time for informal discussions and coding.
 - Best student and postdoc presentation prizes.
@@ -53,18 +53,19 @@ Links to previous FEniCS conferences can be found [here](index.md).
 
 The conference will take place at:<br/>
 [University of Chicago | John W. Boyer Center](https://maps.app.goo.gl/ZGsSNiFAddyisY4R6)<br/>
-41 Rue des Grands Moulins<br/>
+41 rue des Grands Moulins<br/>
 75013 Paris<br/>
 France
 
 ## Registration
 
 - Link to the registration form and deadlines will be posted in early 2026.
-- Early bird registration fee will be set around 200€-250€.
+- Early bird registration fee is 290€.
+- Standard registration fee is 350€.
 - All participants must register for the conference.
 - The registration fee includes: conference activities, coffee breaks,
-  conference dinner, social events. The registration fee does not include
-  lunches and it is non refundable.
+  conference dinner, and social events. The registration fee does not include
+  lunches, and it is non-refundable.
 
 ## Abstract submission
 


### PR DESCRIPTION
Corrected punctuation and capitalization errors in the conference details. Updated registration fees for early bird and standard registration.