### PR TITLE
Update important dates for the 2026 conference

### DIFF
--- a/conference/2026.md
+++ b/conference/2026.md
@@ -42,14 +42,14 @@ Links to previous FEniCS conferences can be found [here](index.md).
 
 ## Important dates
 
-- Abstract submission is open: 16 January 2026.
-- Abstract submission deadline: ~~13 March 2026~~ ~~Extended: 27 March 2026, final deadline~~.
+- ~~Abstract submission is open: 16 January 2026~~.
+- ~~Abstract submission deadline:~~ ~~13 March 2026~~ ~~Extended: 27 March 2026, final deadline~~.
 - Registration for the conference is open: 10 April 2026.
-- Early bird registration deadline: ~~15 May 2026~~, Extended: 18 May 2026. 
+- ~~Applicants for travel awards are informed of the committee’s decision: 18
+  April 2026.~~
+- ~~Participants are informed about the abstract acceptance: 22 April 2026.~~
+- ~~Early bird registration deadline:~~ ~~15 May 2026~~, ~~Extended: 18 May 2026.~~
 - Standard registration deadline: 1 June 2026.
-- Applicants for travel awards are informed of the committee’s decision: 18
-  April 2026.
-- Participants are informed about the abstract acceptance: 22 April 2026.
 - Conference: 17-19 June 2026.
 
 ## Features


### PR DESCRIPTION
Removed outdated information regarding abstract submission and registration deadlines for the 2026 conference.