### PR TITLE
Update build prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ version number to update, do not use these and write the version number.)
 The prerequisites for building the website can be installed by running:
 
 ```bash
-sudo apt-get install -y ruby-bundler
+apt-get update
+apt-get install -y build-essential ruby-dev
 bundle install
 ```
 


### PR DESCRIPTION
Previous prerequisites for building the website don't work if one runs from the latest dolfinx containers (v0.10, v0.11).

These should be enough
```shell
apt-get update
apt-get install -y build-essential ruby-dev
```